### PR TITLE
Fix config.h location in dll_mpfr_tests

### DIFF
--- a/build.vc14/dll_mpfr_tests/mpf_compat/mpf_compat.vcxproj
+++ b/build.vc14/dll_mpfr_tests/mpf_compat/mpf_compat.vcxproj
@@ -90,7 +90,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -114,7 +114,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -135,7 +135,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -162,7 +162,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/mpfr_compat/mpfr_compat.vcxproj
+++ b/build.vc14/dll_mpfr_tests/mpfr_compat/mpfr_compat.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/reuse/reuse.vcxproj
+++ b/build.vc14/dll_mpfr_tests/reuse/reuse.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tabort_defalloc1/tabort_defalloc1.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tabort_defalloc1/tabort_defalloc1.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tabort_defalloc2/tabort_defalloc2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tabort_defalloc2/tabort_defalloc2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tabort_prec_max/tabort_prec_max.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tabort_prec_max/tabort_prec_max.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tabs/tabs.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tabs/tabs.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tacos/tacos.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tacos/tacos.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tacosh/tacosh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tacosh/tacosh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tadd/tadd.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tadd/tadd.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tadd1sp/tadd1sp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tadd1sp/tadd1sp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tadd_d/tadd_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tadd_d/tadd_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tadd_ui/tadd_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tadd_ui/tadd_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tagm/tagm.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tagm/tagm.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tai/tai.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tai/tai.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/talloc/talloc.vcxproj
+++ b/build.vc14/dll_mpfr_tests/talloc/talloc.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tasin/tasin.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tasin/tasin.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tasinh/tasinh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tasinh/tasinh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tassert/tassert.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tassert/tassert.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tatan/tatan.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tatan/tatan.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tatanh/tatanh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tatanh/tatanh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/taway/taway.vcxproj
+++ b/build.vc14/dll_mpfr_tests/taway/taway.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tbuildopt/tbuildopt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tbuildopt/tbuildopt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcan_round/tcan_round.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcan_round/tcan_round.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcbrt/tcbrt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcbrt/tcbrt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcheck/tcheck.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcheck/tcheck.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmp/tcmp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmp/tcmp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmp2/tcmp2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmp2/tcmp2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmp_d/tcmp_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmp_d/tcmp_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmp_ld/tcmp_ld.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmp_ld/tcmp_ld.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmp_ui/tcmp_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmp_ui/tcmp_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcmpabs/tcmpabs.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcmpabs/tcmpabs.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcomparisons/tcomparisons.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcomparisons/tcomparisons.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tconst_catalan/tconst_catalan.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tconst_catalan/tconst_catalan.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tconst_euler/tconst_euler.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tconst_euler/tconst_euler.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tconst_log2/tconst_log2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tconst_log2/tconst_log2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tconst_pi/tconst_pi.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tconst_pi/tconst_pi.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcopysign/tcopysign.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcopysign/tcopysign.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcos/tcos.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcos/tcos.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcosh/tcosh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcosh/tcosh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcot/tcot.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcot/tcot.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcoth/tcoth.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcoth/tcoth.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcsc/tcsc.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcsc/tcsc.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tcsch/tcsch.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tcsch/tcsch.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/td_div/td_div.vcxproj
+++ b/build.vc14/dll_mpfr_tests/td_div/td_div.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/td_sub/td_sub.vcxproj
+++ b/build.vc14/dll_mpfr_tests/td_sub/td_sub.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tdigamma/tdigamma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tdigamma/tdigamma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tdim/tdim.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tdim/tdim.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tdiv/tdiv.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tdiv/tdiv.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tdiv_d/tdiv_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tdiv_d/tdiv_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tdiv_ui/tdiv_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tdiv_ui/tdiv_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/teint/teint.vcxproj
+++ b/build.vc14/dll_mpfr_tests/teint/teint.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/teq/teq.vcxproj
+++ b/build.vc14/dll_mpfr_tests/teq/teq.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/terandom/terandom.vcxproj
+++ b/build.vc14/dll_mpfr_tests/terandom/terandom.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/terandom_chisq/terandom_chisq.vcxproj
+++ b/build.vc14/dll_mpfr_tests/terandom_chisq/terandom_chisq.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/terf/terf.vcxproj
+++ b/build.vc14/dll_mpfr_tests/terf/terf.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/texceptions/texceptions.vcxproj
+++ b/build.vc14/dll_mpfr_tests/texceptions/texceptions.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/texp/texp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/texp/texp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/texp10/texp10.vcxproj
+++ b/build.vc14/dll_mpfr_tests/texp10/texp10.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/texp2/texp2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/texp2/texp2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/texpm1/texpm1.vcxproj
+++ b/build.vc14/dll_mpfr_tests/texpm1/texpm1.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfactorial/tfactorial.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfactorial/tfactorial.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfits/tfits.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfits/tfits.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfma/tfma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfma/tfma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfmma/tfmma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfmma/tfmma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfmod/tfmod.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfmod/tfmod.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfms/tfms.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfms/tfms.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfpif/tfpif.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfpif/tfpif.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfprintf/tfprintf.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfprintf/tfprintf.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfrac/tfrac.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfrac/tfrac.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tfrexp/tfrexp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tfrexp/tfrexp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tgamma/tgamma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tgamma/tgamma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tgamma_inc/tgamma_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tgamma_inc/tgamma_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_d/tget_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_d/tget_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_d_2exp/tget_d_2exp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_d_2exp/tget_d_2exp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_f/tget_f.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_f/tget_f.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_flt/tget_flt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_flt/tget_flt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_ld_2exp/tget_ld_2exp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_ld_2exp/tget_ld_2exp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_set_d64/tget_set_d64.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_set_d64/tget_set_d64.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_sj/tget_sj.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_sj/tget_sj.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_str/tget_str.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_str/tget_str.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tget_z/tget_z.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tget_z/tget_z.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tgmpop/tgmpop.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tgmpop/tgmpop.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tgrandom/tgrandom.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tgrandom/tgrandom.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/thyperbolic/thyperbolic.vcxproj
+++ b/build.vc14/dll_mpfr_tests/thyperbolic/thyperbolic.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/thypot/thypot.vcxproj
+++ b/build.vc14/dll_mpfr_tests/thypot/thypot.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tinits/tinits.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tinits/tinits.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tinp_str/tinp_str.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tinp_str/tinp_str.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tinternals/tinternals.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tinternals/tinternals.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tisnan/tisnan.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tisnan/tisnan.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tisqrt/tisqrt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tisqrt/tisqrt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tj0/tj0.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tj0/tj0.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tj1/tj1.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tj1/tj1.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tjn/tjn.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tjn/tjn.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tl2b/tl2b.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tl2b/tl2b.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlgamma/tlgamma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlgamma/tlgamma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tli2/tli2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tli2/tli2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlngamma/tlngamma.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlngamma/tlngamma.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlog/tlog.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlog/tlog.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlog10/tlog10.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlog10/tlog10.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlog1p/tlog1p.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlog1p/tlog1p.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlog2/tlog2.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlog2/tlog2.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tlog_ui/tlog_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tlog_ui/tlog_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmin_prec/tmin_prec.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmin_prec/tmin_prec.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tminmax/tminmax.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tminmax/tminmax.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmodf/tmodf.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmodf/tmodf.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmul/tmul.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmul/tmul.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmul_2exp/tmul_2exp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmul_2exp/tmul_2exp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmul_d/tmul_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmul_d/tmul_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tmul_ui/tmul_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tmul_ui/tmul_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tnext/tnext.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tnext/tnext.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tnrandom/tnrandom.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tnrandom/tnrandom.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tnrandom_chisq/tnrandom_chisq.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tnrandom_chisq/tnrandom_chisq.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tout_str/tout_str.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tout_str/tout_str.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/toutimpl/toutimpl.vcxproj
+++ b/build.vc14/dll_mpfr_tests/toutimpl/toutimpl.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tpow/tpow.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tpow/tpow.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tpow3/tpow3.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tpow3/tpow3.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tpow_all/tpow_all.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tpow_all/tpow_all.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tpow_z/tpow_z.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tpow_z/tpow_z.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tprintf/tprintf.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tprintf/tprintf.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/trandom/trandom.vcxproj
+++ b/build.vc14/dll_mpfr_tests/trandom/trandom.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/trandom_deviate/trandom_deviate.vcxproj
+++ b/build.vc14/dll_mpfr_tests/trandom_deviate/trandom_deviate.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/trec_sqrt/trec_sqrt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/trec_sqrt/trec_sqrt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tremquo/tremquo.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tremquo/tremquo.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/trint/trint.vcxproj
+++ b/build.vc14/dll_mpfr_tests/trint/trint.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/trndna/trndna.vcxproj
+++ b/build.vc14/dll_mpfr_tests/trndna/trndna.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/troot/troot.vcxproj
+++ b/build.vc14/dll_mpfr_tests/troot/troot.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tround_prec/tround_prec.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tround_prec/tround_prec.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsec/tsec.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsec/tsec.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsech/tsech.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsech/tsech.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset/tset.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset/tset.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_d/tset_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_d/tset_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_exp/tset_exp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_exp/tset_exp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_f/tset_f.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_f/tset_f.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_float128/tset_float128.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_float128/tset_float128.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_ld/tset_ld.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_ld/tset_ld.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_q/tset_q.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_q/tset_q.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_si/tset_si.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_si/tset_si.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_sj/tset_sj.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_sj/tset_sj.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_str/tset_str.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_str/tset_str.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_z/tset_z.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_z/tset_z.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tset_z_exp/tset_z_exp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tset_z_exp/tset_z_exp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsgn/tsgn.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsgn/tsgn.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsi_op/tsi_op.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsi_op/tsi_op.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsin/tsin.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsin/tsin.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsin_cos/tsin_cos.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsin_cos/tsin_cos.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsinh/tsinh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsinh/tsinh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsinh_cosh/tsinh_cosh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsinh_cosh/tsinh_cosh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsprintf/tsprintf.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsprintf/tsprintf.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsqr/tsqr.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsqr/tsqr.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsqrt/tsqrt.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsqrt/tsqrt.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsqrt_ui/tsqrt_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsqrt_ui/tsqrt_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tstckintc/tstckintc.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tstckintc/tstckintc.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tstdint/tstdint.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tstdint/tstdint.vcxproj
@@ -99,7 +99,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -123,7 +123,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -144,7 +144,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -171,7 +171,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tstrtofr/tstrtofr.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tstrtofr/tstrtofr.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsub/tsub.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsub/tsub.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsub1sp/tsub1sp.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsub1sp/tsub1sp.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsub_d/tsub_d.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsub_d/tsub_d.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsub_ui/tsub_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsub_ui/tsub_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsubnormal/tsubnormal.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsubnormal/tsubnormal.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tsum/tsum.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tsum/tsum.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tswap/tswap.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tswap/tswap.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/ttan/ttan.vcxproj
+++ b/build.vc14/dll_mpfr_tests/ttan/ttan.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/ttanh/ttanh.vcxproj
+++ b/build.vc14/dll_mpfr_tests/ttanh/ttanh.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/ttrunc/ttrunc.vcxproj
+++ b/build.vc14/dll_mpfr_tests/ttrunc/ttrunc.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tui_div/tui_div.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tui_div/tui_div.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tui_pow/tui_pow.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tui_pow/tui_pow.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tui_sub/tui_sub.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tui_sub/tui_sub.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/turandom/turandom.vcxproj
+++ b/build.vc14/dll_mpfr_tests/turandom/turandom.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tvalist/tvalist.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tvalist/tvalist.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tversion/tversion.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tversion/tversion.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/ty0/ty0.vcxproj
+++ b/build.vc14/dll_mpfr_tests/ty0/ty0.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/ty1/ty1.vcxproj
+++ b/build.vc14/dll_mpfr_tests/ty1/ty1.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tyn/tyn.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tyn/tyn.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tzeta/tzeta.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tzeta/tzeta.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/build.vc14/dll_mpfr_tests/tzeta_ui/tzeta_ui.vcxproj
+++ b/build.vc14/dll_mpfr_tests/tzeta_ui/tzeta_ui.vcxproj
@@ -98,7 +98,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,7 +122,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -143,7 +143,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -170,7 +170,7 @@
       </PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ForcedIncludeFiles>..\..\..\..\mpir\lib\$(IntDir)\config.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles>..\..\..\..\mpir\dll\$(IntDir)\config.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(IntDir)lib_tests.lib;..\..\..\dll\$(IntDir)mpfr.lib;..\..\..\..\mpir\dll\$(IntDir)mpir.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
This error is noticeable only when `lib_mpfr` was not built.